### PR TITLE
HPC compliance checker fixes and remaining benchmark rules

### DIFF
--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_common.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_common.yaml
@@ -2,7 +2,7 @@
 - KEY:
     NAME:  submission_benchmark
     REQ:   EXACTLY_ONE
-    CHECK: " v['value'] in ['deepcam', 'deepcam', 'cosmoflow', 'dimenet'] "
+    CHECK: " v['value'] in ['deepcam', 'deepcam', 'cosmoflow', 'oc20'] "
     POST:  " enqueue_config('hpc_1.0.0/closed_{}.yaml'.format(v['value'])) "
 
 - KEY:

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_common.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_common.yaml
@@ -7,10 +7,8 @@
 
 - KEY:
     NAME:  gradient_accumulation_steps
-    REQ:   AT_LEAST_ONE_OR(gradient_accumulation_frequency)
     CHECK: " v['value'] > 0 "
 
 - KEY:
     NAME:  gradient_accumulation_frequency
-    REQ:   AT_LEAST_ONE_OR(gradient_accumulation_steps)
     CHECK: " v['value'] > 0 "

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_cosmoflow.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_cosmoflow.yaml
@@ -1,0 +1,47 @@
+- KEY:
+    NAME:  global_batch_size
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] > 0"
+
+- KEY:
+    NAME:  opt_name
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] in ['sgd', 'SGD'] "
+
+- KEY:
+    NAME:  opt_base_learning_rate
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0."
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_epochs
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0"
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_factor
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0."
+
+- KEY:
+    NAME:  opt_learning_rate_decay_boundary_epochs
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_learning_rate_decay_factor
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  dropout
+    CHECK: " v['value'] >= 0. and v['value'] < 1."
+
+- KEY:
+    NAME: opt_weight_decay
+    CHECK: " v['value'] >= 0."
+
+- KEY:
+    NAME:  eval_error
+    REQ:   AT_LEAST_ONE
+    CHECK:
+        - "'epoch_num' in v['metadata']"
+    ATLEAST_ONE_CHECK: "v['value'] <= 0.124 and v['value'] > 0."

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_oc20.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_oc20.yaml
@@ -1,0 +1,39 @@
+- KEY:
+    NAME:  global_batch_size
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] > 0"
+
+- KEY:
+    NAME:  opt_name
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 'AdamW'"
+
+- KEY:
+    NAME:  opt_base_learning_rate
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0."
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_steps
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0"
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_factor
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0."
+
+- KEY:
+    NAME:  opt_learning_rate_decay_boundary_steps
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_learning_rate_decay_factor
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  eval_error
+    REQ:   AT_LEAST_ONE
+    CHECK:
+        - "'epoch_num' in v['metadata']"
+    ATLEAST_ONE_CHECK: "v['value'] <= 0.036 and v['value'] > 0."

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/common.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/common.yaml
@@ -145,12 +145,6 @@
         - "'epoch_num' in v['metadata']"
 
 - KEY:
-    NAME:  eval_accuracy
-    REQ:   AT_LEAST_ONE
-    CHECK:
-        - "'epoch_num' in v['metadata']"
-
-- KEY:
     NAME:  train_samples
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] != '' "

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/open_cosmoflow.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/open_cosmoflow.yaml
@@ -1,0 +1,6 @@
+- KEY:
+    NAME:  eval_error
+    REQ:   AT_LEAST_ONE
+    CHECK:
+        - "'epoch_num' in v['metadata']"
+    ATLEAST_ONE_CHECK: "v['value'] <= 0.124 and v['value'] > 0."

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/open_oc20.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/open_oc20.yaml
@@ -1,0 +1,6 @@
+- KEY:
+    NAME:  eval_error
+    REQ:   AT_LEAST_ONE
+    CHECK:
+        - "'epoch_num' in v['metadata']"
+    ATLEAST_ONE_CHECK: "v['value'] <= 0.036 and v['value'] > 0."

--- a/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_cosmoflow.json
+++ b/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_cosmoflow.json
@@ -1,0 +1,18 @@
+{
+    "cosmoflow_ref_64": {
+        "Benchmark": "cosmoflow",
+        "BS": 64,
+        "Epochs to converge": [ 18, 17, 19, 16, 17, 18, 17, 17, 17, 17, 17, 17, 17, 18, 17, 17, 17, 17, 17, 19 ],
+        "Hyperparams": {
+            "global_batch_size": 64,
+            "opt_name": "SGD",
+            "opt_base_learning_rate": 0.001,
+            "opt_learning_rate_warmup_epochs": 4,
+            "opt_learning_rate_warmup_factor": 1.0,
+            "opt_learning_rate_decay_boundary_epochs": [ 16, 32 ],
+            "opt_learning_rate_decay_factor": 0.25,
+            "dropout": 0.0,
+            "opt_weight_decay": 0.01
+        }
+    }
+}


### PR DESCRIPTION
Some fixes and the other two benchmarks, to propagate to your PR.

I renamed dimenet to oc20 as this is what the reference code logs. It's not perfect but might as well just stick with something to avoid getting noncompliant logs from folks.

I removed the requirement of logging the gradient accumulation settings. Gradient accumulation wasn't used in hpc v0.7 and the reference codes still don't log it, so I don't think we should require it right now. If folks use it, they should log it, so we still check the values.

I removed the eval_accuracy requirement from common.yaml, since we use eval_error in the other benchmarks instead. This fixes my comment on your PR.